### PR TITLE
put the External Links section side-by-side with the main content

### DIFF
--- a/css/responsive-design/style.css
+++ b/css/responsive-design/style.css
@@ -9,11 +9,15 @@ cite {
   margin-top: 10px;
 }
 
+#external-links {
+  width: 20%;
+  display:inline-block;
+  vertical-align:top;
+}
+
 #external-links ul {
   list-style-type: none;
   padding-left: 0px;
-  width: 50%;
-  vertical-align: middle;
 }
 
 /* you're welcome to edit the
@@ -38,13 +42,8 @@ body {
 }
 
 main {
-  width: 80%;
-  display: inline-block;
-}
-
-#wrapper {
-  margin: 0 auto;
-  width: 90%;
+  width: 70%;
+  display:inline-block;
 }
 
 @media screen and (max-width: 500px) {


### PR DESCRIPTION
use the display and vertical-align properties to put the External Links section side-by-side with the main content - fix
